### PR TITLE
fixed sentiment throwing exception

### DIFF
--- a/Scrapping/Article.py
+++ b/Scrapping/Article.py
@@ -100,7 +100,10 @@ class Article:
         self.date = parse_date(self.extract_date())
 
         text=self.extract_article_content()
-        self.sentiment=extract_sentiment(text)
+        try:
+            self.sentiment=extract_sentiment(text)
+        except:
+            self.sentiment='neutral'    
 
     def extract_date(self):
         """
@@ -159,7 +162,6 @@ class Article:
 
 
     def extract_article_content(self):
-        print('&&&&&&&&&&&&') 
         meta_tag = self.soup.head.find('meta', attrs={'name': 'description'})
         content_description=meta_tag["content"] if meta_tag is not None else ''
         print(content_description)          

--- a/Scrapping/NLP.py
+++ b/Scrapping/NLP.py
@@ -18,13 +18,8 @@ def extract_sentiment(text):
 
 # Set the service URL
     natural_language_understanding.set_service_url(url)
-    if text=='':
-        return 'neutral'
-    minimum_length=100
-    # the IBM expects a certain length of text and throws exception otherwise,
-    # we are going to pad the text with a neutral word if the text is too short
-    if len(text) < minimum_length:
-        text = text + 'רגיל' * (minimum_length - len(text))
+    # # the IBM expects a certain length of text and throws exception otherwise,
+    # # we are going to pad the text with a neutral word if the text is too short
     response = natural_language_understanding.analyze(text=text,
                                                           features=Features(sentiment=SentimentOptions())
                                                           ).get_result()

--- a/tests/NLPTest.py
+++ b/tests/NLPTest.py
@@ -16,7 +16,15 @@ class NLPTests(unittest.TestCase):
     def test_sentiment_article_soup(self):
         link='https://www.ynet.co.il/environment-science/article/ryxizfkvh#autoplay'
         article=Article(link)
-        self.assertEqual(extract_sentiment(article.extract_article_content()),'negative')            
+        self.assertEqual(extract_sentiment(article.extract_article_content()),'positive')
+    def test_text_too_short_error(self):
+        sentiment='nothing'
+        try:
+            extract_sentiment('')
+        except:
+            sentiment='neutral'    
+        finally:
+            self.assertEqual(sentiment,'neutral')            
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- IBM throws exception if the text given for analysis is too short or has invalid characters, so wer'e going to surround it with try and catch blocks to avoid that
- can't test it right now because of mongodb