### PR TITLE
Bugfix concurrent queriesshowing incorrectly

### DIFF
--- a/API/API.py
+++ b/API/API.py
@@ -119,10 +119,11 @@ def default_select_table():
     table = select_all.select_articles_from_sql()
     return make_response(jsonify(results=table), 200)
 
-
+#TODO: delete the generated table
 @app.route('/clear', methods=['POST'])
 def clear_table():
     clear_query = SQLQuery()
+    #delete the generated table
     clear_query.clear_table()
     return make_response("table cleared", 200)
 
@@ -130,7 +131,7 @@ def get_default_websites():
     websites_to_search= ["www.ynet.co.il","www.israelhayom.co.il"] 
     return  websites_to_search
 
-def scrap_links(links_to_scrap,keywords_intonation_list,phrase_intonation_list,category='1'):
+def scrap_links(links_to_scrap,keywords_intonation_list,phrase_intonation_list,table_id,category='1'):
     #TODO: scrap phrases and keywords differently
     '''
     scrapping information about each keyword and website
@@ -157,7 +158,7 @@ def scrap_links(links_to_scrap,keywords_intonation_list,phrase_intonation_list,c
                 phrase_intonation_list,
                 category)
                 insert_query=SQLQuery()
-                insert_query.insert_article_to_sql(rows_to_add)
+                insert_query.insert_article_to_sql(rows_to_add,table_id)
             except HTTPError:
                 make_response("This website is forbidden to scrap",403)   
 
@@ -192,9 +193,11 @@ def do_search_query(category='1'):
             negative_keywords=negative_keywords
         )
     # Perform the search and scrape the links for each website
+    table_id=SQLQuery().generate_table()
     for website in site_list:
         search_results = search_google(query, website)
-        scrap_links(search_results, keyword_to_intonation,phrase_to_intonation, category)
+        scrap_links(search_results, keyword_to_intonation,phrase_to_intonation,table_id,category)
+    return table_id    
 
 
 
@@ -204,9 +207,9 @@ def get_database_query():
     '''
     search and scrap 2 categories, and then return a response when finished
     '''
-    do_search_query('1')
+    table_id=do_search_query('1')
     # do_search_query('2')
-    return make_response("OK", 200)  
+    return make_response(str(table_id), 200)  
 
 
 def search_google(query, site_list, exclude_query=''):
@@ -234,21 +237,21 @@ def parse_table_rows(rows):
     return [row[0] for row in rows]
 
 
-def include_exclude_lists(universe, included, excluded):
-    '''
-    prevents repetition in searching included and excluded keywords, websites etc.
-    | is the union operator
-    '''
-    return list((set(universe) | set(included)) - set(excluded))
+# def include_exclude_lists(universe, included, excluded):
+#     '''
+#     prevents repetition in searching included and excluded keywords, websites etc.
+#     | is the union operator
+#     '''
+#     return list((set(universe) | set(included)) - set(excluded))
 
 
-def create_parameters_list(included_field, excluded_field):
-    '''
-    returns a list of the parameters we want in the search, and without the ones we want to exclude
-    '''
-    included_parameters = parse_json_and_strip(included_field)
-    excluded_parameters = parse_json_and_strip(excluded_field)
-    return include_exclude_lists([], included_parameters, excluded_parameters)
+# def create_parameters_list(included_field, excluded_field):
+#     '''
+#     returns a list of the parameters we want in the search, and without the ones we want to exclude
+#     '''
+#     included_parameters = parse_json_and_strip(included_field)
+#     excluded_parameters = parse_json_and_strip(excluded_field)
+#     return include_exclude_lists([], included_parameters, excluded_parameters)
 
 
 def is_at_least_one_keyword(category='1'):
@@ -349,10 +352,13 @@ def advanced_search_query(category='1'):
     _, decoded_exclude = url_encode_keywords(keywords_to_exclude)
     exclude_query = ','.join(decoded_exclude)
     
+
+    table_id=SQLQuery().generate_table()
     for website in websites_to_search:
         links_to_scrap = search_google(query, website, exclude_query)
-        scrap_links(links_to_scrap,keyword_to_intonation,phrases_to_intonation,category)
+        scrap_links(links_to_scrap,keyword_to_intonation,phrases_to_intonation,table_id,category)
     # TODO: specify dates in the google search
+    return table_id
 
 def url_encode_keywords(keywords):
     """
@@ -378,10 +384,11 @@ def advanced_search():
     returns bad request if there are no keywords in the search query
     otherwise returns ok
     '''
-    advanced_search_query('1')
+    
+    table_id=advanced_search_query('1')
     
     # not adding specified statistics yet, because there is only counter for now
-    return make_response("ok", 200)
+    return make_response(str(table_id), 200)
 
 
 # driver function

--- a/API/API.py
+++ b/API/API.py
@@ -113,18 +113,21 @@ def parse_google_search_query(query):
 app = Flask(__name__)
 
 
-@app.route('/rows', methods=['POST'])
-def default_select_table():
-    select_all = SQLQuery()
-    table = select_all.select_articles_from_sql()
-    return make_response(jsonify(results=table), 200)
+# @app.route('/rows', methods=['POST'])
+# def default_select_table():
+#     select_all = SQLQuery()
+#     table = select_all.select_articles_from_sql()
+#     return make_response(jsonify(results=table), 200)
 
-#TODO: delete the generated table
+
 @app.route('/clear', methods=['POST'])
 def clear_table():
+
     clear_query = SQLQuery()
-    #delete the generated table
-    clear_query.clear_table()
+    #which table do we clear:
+    table_id=request.json.get('table_id', "")
+    if table_id!="":
+        clear_query.delete_table(table_id=table_id)
     return make_response("table cleared", 200)
 
 def get_default_websites():

--- a/SQL/SqlQueries.py
+++ b/SQL/SqlQueries.py
@@ -111,7 +111,7 @@ class SQLQuery:
         returns the id of the generated table as string
         """
         table_id=str(random.randint(0,upper_limit))
-        create_query = "CREATE TABLE Articles"+table_id+"(website TEXT,keyword TEXT,date DATE,count INT,link TEXT,intonation BOOLEAN,category TEXT,score Numeric(4,3),PRIMARY KEY (link,keyword));"
+        create_query = "CREATE TABLE Articles"+table_id+"(website TEXT,keyword TEXT,date DATE,count INT,link TEXT,intonation TEXT,category TEXT,score Numeric(4,3),PRIMARY KEY (link,keyword));"
         self.execute_query(create_query)
         return table_id
     def delete_table(self,table_id):

--- a/SQL/SqlQueries.py
+++ b/SQL/SqlQueries.py
@@ -1,5 +1,6 @@
 import psycopg2
 import sys
+import random
 
 sys.path.append('..\\Scrapping')
 from Scrapping.Article import *
@@ -39,7 +40,7 @@ class SQLQuery:
             if conn is not None:
                 conn.close()
 
-    def insert_article_to_sql(self, keyword_list):
+    def insert_article_to_sql(self, keyword_list,id=""):
         """
     insert the keyword_list given as parameter to our SQL server
     :param keyword_list: the rows you want to insert to the database
@@ -49,7 +50,7 @@ class SQLQuery:
 
     """
 
-        insert_sql = "INSERT INTO Articles(website,keyword,date,count,link,intonation,category,score) " \
+        insert_sql = "INSERT INTO Articles"+str(id)+"(website,keyword,date,count,link,intonation,category,score) " \
                      "VALUES(%s,%s,%s,%s,%s,%s,%s,%s);"
         self.execute_query(insert_sql, keyword_list)
     def insert_keyword_intonation_to_sql(self,keyword_intonation_list):
@@ -73,13 +74,13 @@ class SQLQuery:
             if conn:
                 cur.close()
                 conn.close()
-    def select_articles_from_sql(self, columns="*", conditions=None):
+    def select_articles_from_sql(self, columns="*", conditions=None,id=""):
         """
         """
         if conditions is not None:
-            select_query = f"SELECT {columns} FROM Articles WHERE {conditions}"
+            select_query = f"SELECT {columns} FROM Articles"+str(id)+f" WHERE {conditions}"
         else:
-            select_query = f"SELECT {columns} FROM Articles"
+            select_query = f"SELECT {columns} FROM Articles"+str(id)
         conn = None
         cur = None
         try:
@@ -102,4 +103,21 @@ class SQLQuery:
         unlike DROP and DELETE
         """
         clear_query = "TRUNCATE TABLE Articles"
+        self.execute_query(clear_query)
+    def generate_table(self,upper_limit=1000):
+        """
+        Create a random Articles table to store the results,
+        so that concurrent requests will not show incorrectly
+        returns the id of the generated table as string
+        """
+        table_id=str(random.randint(0,upper_limit))
+        create_query = "CREATE TABLE Articles"+table_id+"(website TEXT,keyword TEXT,date DATE,count INT,link TEXT,intonation BOOLEAN,category TEXT,score Numeric(4,3),PRIMARY KEY (link,keyword));"
+        self.execute_query(create_query)
+        return table_id
+    def delete_table(self,table_id):
+        """
+        clears all records from the table and removes it permenantly
+        unlike TRUNCATE 
+        """
+        clear_query = "DROP TABLE Articles"+str(table_id)
         self.execute_query(clear_query)

--- a/tests/SqlQueriesTest.py
+++ b/tests/SqlQueriesTest.py
@@ -19,6 +19,10 @@ class MyTestCase(unittest.TestCase):
         keyword_list = [('example1', "False"), ('example2', "neutral")]
         rows = article.create_rows_to_database(keyword_list)
         sql_query.insert_article_to_sql(rows)
+    def test_generate_and_delete_random_table(self):
+        sql_query = SQLQuery()
+        id=sql_query.generate_table()
+        sql_query.delete_table(id)   
 
 
 


### PR DESCRIPTION
Since we had a single table to store the results in, the results of one search would affect the other if they were made concurrently.
This PR attempts to fix this by generating different tables with different ids to avoid these collisions.